### PR TITLE
Improve link coverage reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repo Instructions
+
+- Run `pwsh -NoProfile -Command "Invoke-Pester -Output Detailed"` before committing changes to ensure tests pass.
+- Use four spaces for indentation in PowerShell scripts.
+- All documentation links must be relative and use forward slashes.
+- Index files under `docs` must list every markdown file in their folder. Use the file name as the link label and paths relative to the `docs` root (see commit 99253c70).
+- The markdown link validation tests check that all links in index files exist and report the percentage of markdown files that are referenced. Missing references are printed but do not fail the tests.
+- When adding documentation, update the corresponding `index.md` so coverage remains high.

--- a/Tests/ValidateMarkdownLinks.Tests.ps1
+++ b/Tests/ValidateMarkdownLinks.Tests.ps1
@@ -22,8 +22,9 @@ Describe "Validate links in all index.md files" {
         $mdFiles = Get-ChildItem -Path $PathToTest -Filter index.md -Recurse -File
 
         foreach ($file in $mdFiles) {
-            #TODO: Context should show relative path starting from $RootPath (Replace $($file.Directory.Name))
-            Context "Folder: $($file.Directory.Name)" {
+            $relativeDir = [System.IO.Path]::GetRelativePath($RootPath, $file.Directory.FullName)
+            $relativeDir = $relativeDir -replace '\\', '/'
+            Context "Folder: $relativeDir" {
                 $content = Get-Content -Path $file.FullName -Raw
                 $links = Get-MarkdownLinks -Content $content | Where-Object { $_ -imatch '.md' }
                 
@@ -40,7 +41,37 @@ Describe "Validate links in all index.md files" {
             }
         }
 
-        #TODO: Another test should get the coverage of existing Markdown files linked in indexes.
+        Context "Coverage of markdown files referenced in indexes" {
+            It "outputs markdown coverage" {
+                $allLinks = foreach ($idx in $mdFiles) {
+                    $idxContent = Get-Content -Path $idx.FullName -Raw
+                    Get-MarkdownLinks -Content $idxContent | Where-Object { $_ -imatch '.md' } |
+                        ForEach-Object { $_.Replace('<', '').Replace('>', '') }
+                }
+
+                $allLinks = $allLinks | Select-Object -Unique
+
+                $allMdFiles = Get-ChildItem -Path $PathToTest -Filter *.md -Recurse -File | Where-Object { $_.Name -ne 'index.md' }
+
+                $notLinked = foreach ($md in $allMdFiles) {
+                    $relative = [System.IO.Path]::GetRelativePath($RootPath, $md.FullName) -replace '\\', '/'
+                    if ($allLinks -notcontains $relative) { $relative }
+                }
+
+                $coverage = if ($allMdFiles.Count -gt 0) {
+                    [math]::Round((($allMdFiles.Count - $notLinked.Count) / $allMdFiles.Count) * 100, 2)
+                } else { 100 }
+
+                Write-Host "Markdown coverage: $coverage% ($($allMdFiles.Count - $notLinked.Count)/$($allMdFiles.Count))"
+
+                if ($notLinked) {
+                    Write-Host "Unlinked files:" 
+                    $notLinked | ForEach-Object { Write-Host " - $_" }
+                }
+
+                $true | Should -BeTrue
+            }
+        }
     }
 
 }

--- a/Tests/ValidateMarkdownLinks.Tests.ps1
+++ b/Tests/ValidateMarkdownLinks.Tests.ps1
@@ -46,7 +46,7 @@ Describe "Validate links in all index.md files" {
                 $allLinks = foreach ($idx in $mdFiles) {
                     $idxContent = Get-Content -Path $idx.FullName -Raw
                     Get-MarkdownLinks -Content $idxContent | Where-Object { $_ -imatch '.md' } |
-                        ForEach-Object { $_.Replace('<', '').Replace('>', '') }
+                        ForEach-Object { $_.Trim('<>') }
                 }
 
                 $allLinks = $allLinks | Select-Object -Unique

--- a/Tests/ValidateMarkdownLinks.Tests.ps1
+++ b/Tests/ValidateMarkdownLinks.Tests.ps1
@@ -55,7 +55,7 @@ Describe "Validate links in all index.md files" {
 
                 $notLinked = foreach ($md in $allMdFiles) {
                     $relative = [System.IO.Path]::GetRelativePath($RootPath, $md.FullName) -replace '\\', '/'
-                    if ($allLinks -notcontains $relative) { $relative }
+                    if ($allLinks -inotcontains $relative) { $relative }
                 }
 
                 $coverage = if ($allMdFiles.Count -gt 0) {


### PR DESCRIPTION
### **User description**
## Summary
- document more detailed repo guidelines in `AGENTS.md`
- adjust coverage test so it prints percentage and missing files instead of failing

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -Output Detailed"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4693a5288321ba67ee27ad8dcb70


___

### **PR Type**
Documentation, Tests


___

### **Description**
- Add comprehensive repository guidelines in `AGENTS.md`

- Enhance markdown link coverage test with percentage reporting

- Replace TODO comments with functional coverage implementation

- Improve test context display with relative paths


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Add comprehensive repository development guidelines</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<li>Create new documentation file with repository guidelines<br> <li> Define PowerShell testing, indentation, and documentation standards<br> <li> Specify markdown link validation and coverage requirements


</details>


  </td>
  <td><a href="https://github.com/Thamielis/Notes/pull/4/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ValidateMarkdownLinks.Tests.ps1</strong><dd><code>Enhance markdown link validation with coverage reporting</code>&nbsp; </dd></summary>
<hr>

Tests/ValidateMarkdownLinks.Tests.ps1

<li>Replace hardcoded folder names with relative paths in test contexts<br> <li> Add new coverage test that calculates and reports markdown file <br>linking percentage<br> <li> Remove TODO comments and implement missing functionality<br> <li> Display unlinked files without failing tests


</details>


  </td>
  <td><a href="https://github.com/Thamielis/Notes/pull/4/files#diff-fb34fe32028aab0e8cc4f8022be8648642db08be03023009b5ead411fc375bd4">+34/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>